### PR TITLE
Fix publish by fetching NPM user access token from AWS secrets manager

### DIFF
--- a/.github/workflows/publishWorkflow.yml
+++ b/.github/workflows/publishWorkflow.yml
@@ -13,6 +13,14 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.1.34"
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_IAM_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            NPM_USER_ACCESS_TOKEN,${{ vars.NPM_USER_ACCESS_TOKEN_SECRET_ARN }}
       - uses: mangs/simple-release-notes-action@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -21,4 +29,4 @@ jobs:
         with:
           access: public
           registry: https://registry.npmjs.org/
-          token: ${{ secrets.NPM_USER_ACCESS_TOKEN }}
+          token: ${{ env.NPM_USER_ACCESS_TOKEN }}

--- a/.github/workflows/pullRequestWorkflow.yml
+++ b/.github/workflows/pullRequestWorkflow.yml
@@ -13,10 +13,10 @@ jobs:
           bun-version: "1.1.34"
       - run: bun install --frozen-lockfile
       - run: bun run check:environment
-      # - run: bun run check:package-version
-      #   env:
-      #     GITHUB_API_URL: ${{ env.GITHUB_API_URL }}
-      #     GITHUB_REF_NAME: ${{ env.GITHUB_REF_NAME }}
-      #     GITHUB_REPOSITORY: ${{ env.GITHUB_REPOSITORY }}
-      #     GITHUB_TOKEN: ${{ github.token }}
+      - run: bun run check:package-version
+        env:
+          GITHUB_API_URL: ${{ env.GITHUB_API_URL }}
+          GITHUB_REF_NAME: ${{ env.GITHUB_REF_NAME }}
+          GITHUB_REPOSITORY: ${{ env.GITHUB_REPOSITORY }}
+          GITHUB_TOKEN: ${{ github.token }}
       - run: bun --bun run check:formatting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.1
+
+- Fix publish by fetching NPM user access token from AWS secrets manager
+- Enable `check:package-version` script execution during CI to enforce version bumps for every pull request
+- Add missing MIT license file to repository
+
 ## 1.0.0
 
 - First public release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix publish by fetching NPM user access token from AWS secrets manager
 - Enable `check:package-version` script execution during CI to enforce version bumps for every pull request
 - Add missing MIT license file to repository
+- Add [`MAINTAINERS.md`](./MAINTAINERS.md)
 
 ## 1.0.0
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Babbel
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,9 @@
 MIT License
 
-Copyright (c) 2024 Babbel
+Copyright 2024 Babbel
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,18 @@
+## These are the current project maintainers
+
+Please keep the list sorted alphabetically by handle
+
+| Github ID                                                      | Name              | Email                   |
+| -------------------------------------------------------------- | ----------------- | ----------------------- |
+| [@jduthon](https://github.com/jduthon)                         | Jean Duthon       | <jduthon@babbel.com>    |
+| [@Jhojan28](https://github.com/Jhojan28)                       | Jhojan Garcia     | <jgarcia@babbel.com>    |
+| [@laurensortiz-babbel](https://github.com/laurensortiz-babbel) | Laurens Ortiz     | <lortiz@babbel.com>     |
+| [@mangs](https://github.com/mangs)                             | Eric L. Goldstein | <egoldstein@babbel.com> |
+| [@pooja-salpekar](https://github.com/pooja-salpekar)           | Pooja Salpekar    | <psalpekar@babbel.com>  |
+| [@serenematt-babbel](https://github.com/serenematt-babbel)     | Serene Mathew     | <smathew@babbel.com>    |
+
+## These are the prior project maintainers
+
+| Github ID | Name | Email |
+| --------- | ---- | ----- |
+| N/A       | N/A  | N/A   |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NPM module `@babbel/stylelint-config`
 
-Hierarchical Stylelint configuration collection that intends to be simple to use, layered, and shared with others [[maintainers]](/config/github/codeOwners)
+Hierarchical Stylelint configuration collection that intends to be simple to use, layered, and shared with others [[maintainers]](./MAINTAINERS.md)
 
 ## Stylelint Configurations
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babbel/stylelint-config",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Eric L. Goldstein <egoldstein@babbel.com>",
   "description": "Hierarchical Stylelint configuration collection that intends to be simple to use, layered, and shared with others",
   "keywords": [


### PR DESCRIPTION
**Pull Request Checklist**

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) document
- [x] Readme and changelog updates were made reflecting this PR's changes

**Changes Included**

- Version bump to `1.0.1`
- Fix publish by fetching NPM user access token from AWS secrets manager
- Enable `check:package-version` script execution during CI to enforce version bumps for every pull request
- Add missing MIT license file to repository
- Add [`MAINTAINERS.md`](./MAINTAINERS.md)