### PR TITLE
Fix improper GitHub Actions workflow variable: `vars.NPM_USER_ACCESS_TOKEN_SECRET_ARN` -> `vars.NPM_USER_ACCESS_TOKEN`

### DIFF
--- a/.github/workflows/publishWorkflow.yml
+++ b/.github/workflows/publishWorkflow.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: |
-            NPM_USER_ACCESS_TOKEN,${{ vars.NPM_USER_ACCESS_TOKEN_SECRET_ARN }}
+            NPM_USER_ACCESS_TOKEN,${{ vars.NPM_USER_ACCESS_TOKEN }}
       - uses: mangs/simple-release-notes-action@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.3
+
+- Fix improper GitHub Actions workflow variable: `vars.NPM_USER_ACCESS_TOKEN_SECRET_ARN` -> `vars.NPM_USER_ACCESS_TOKEN`
+
 ## 1.0.2
 
 - Fix missing OIDC write permission in GitHub Actions publish workflow. This prevents proper package publishing.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babbel/stylelint-config",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": "Eric L. Goldstein <egoldstein@babbel.com>",
   "description": "Hierarchical Stylelint configuration collection that intends to be simple to use, layered, and shared with others",
   "keywords": [


### PR DESCRIPTION
**Pull Request Checklist**

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) document
- [x] Readme and changelog updates were made reflecting this PR's changes

**Changes Included**

- Version bump to `1.0.3`
- Fix improper GitHub Actions workflow variable: `vars.NPM_USER_ACCESS_TOKEN_SECRET_ARN` -> `vars.NPM_USER_ACCESS_TOKEN`