### PR TITLE
Add `write` permission to the GitHub Actions publish workflow to be able to create releases

### DIFF
--- a/.github/workflows/publishWorkflow.yml
+++ b/.github/workflows/publishWorkflow.yml
@@ -6,6 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     permissions:
+      contents: write
       id-token: write
     steps:
       - name: CPU Details

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.5
+
+- Add `write` permission to the GitHub Actions publish workflow to be able to create releases
+
 ## 1.0.4
 
 - Change how NPM user access token is being added into our GitHub Actions workflow environment

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babbel/stylelint-config",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "author": "Eric L. Goldstein <egoldstein@babbel.com>",
   "description": "Hierarchical Stylelint configuration collection that intends to be simple to use, layered, and shared with others",
   "keywords": [


### PR DESCRIPTION
**Pull Request Checklist**

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) document
- [x] Readme and changelog updates were made reflecting this PR's changes

**Changes Included**

- Version bump to `1.0.5`
- Add `write` permission to the GitHub Actions publish workflow to be able to create releases