### PR TITLE
Publish OIDC

### DIFF
--- a/.github/workflows/publishWorkflow.yml
+++ b/.github/workflows/publishWorkflow.yml
@@ -27,4 +27,3 @@ jobs:
         with:
           access: public
           registry: https://registry.npmjs.org/
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.6
+
+- Publish package using OIDC trust
+
 ## 1.0.5
 
 - Add `write` permission to the GitHub Actions publish workflow to be able to create releases

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babbel/stylelint-config",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "author": "Eric L. Goldstein <egoldstein@babbel.com>",
   "description": "Hierarchical Stylelint configuration collection that intends to be simple to use, layered, and shared with others",
   "keywords": [


### PR DESCRIPTION
**Changes Included** Change publish workflow to use OIDC

We would like to use trusted publishing because otherwise we need to periodically rotate the secrets.

This PR introduces publishing to npmjs.org using OIDC as [documented here](https://docs.npmjs.com/trusted-publishers#prefer-trusted-publishing-over-tokens) and [here for JS-DevTools](https://github.com/JS-DevTools/npm-publish).

## Depends-on 

**Pull Request Checklist**

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) document
- [x] Readme and changelog updates were made reflecting this PR's changes
- [x] Increase the project version number in `package.json` following [Semantic Versioning](http://semver.org/)
- [x] enable GitHub/npm OIDC trust in [npm package settings](https://www.npmjs.com/package/@babbel/eslint-config/access) (requires admin permissions)

<img width="798" height="236" alt="Screenshot 2025-12-18 at 17 27 02" src="https://github.com/user-attachments/assets/6693d6c6-dac2-4b69-83e1-b11426558f99" />


**Please note that I accidentally pushed [this commit](https://github.com/babbel/stylelint-config/commit/f2bf0ec4e75e0f456d271d7427d6f52cabbac9b4) to master already. I'm really sorry it happened to me twice.** (I think the default behaviour in the UI changed.)
