### PR TITLE
Restore publishing to NPM repo by token

### DIFF
--- a/.github/workflows/publishWorkflow.yml
+++ b/.github/workflows/publishWorkflow.yml
@@ -19,11 +19,16 @@ jobs:
         with:
           aws-region: ${{ vars.AWS_REGION }}
           role-to-assume: ${{ vars.AWS_IAM_ROLE_ARN }}
+      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          parse-json-secrets: true
+          secret-ids: NPM_USER,${{ vars.NPM_USER_SECRET_ARN }}
       - uses: mangs/simple-release-notes-action@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           should_auto_update_major_tag: false
-      - uses: JS-DevTools/npm-publish@v4
+      - uses: JS-DevTools/npm-publish@v3
         with:
           access: public
           registry: https://registry.npmjs.org/
+          token: ${{ env.NPM_USER_ACCESS_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.7
+
+- Publish to NPM registry using long-lived token
+
 ## 1.0.6
 
 - Publish package using OIDC trust

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babbel/stylelint-config",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "author": "Eric L. Goldstein <egoldstein@babbel.com>",
   "description": "Hierarchical Stylelint configuration collection that intends to be simple to use, layered, and shared with others",
   "keywords": [


### PR DESCRIPTION
Restoring the state of [the last change](https://github.com/babbel/stylelint-config/pull/7) before trying OIDCC because we cannot consistently use OIDC based publishing across repos and  dependency support.